### PR TITLE
Use fluent-style APIs instead of arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,7 @@ name = "tabbed-document-ui"
 version = "0.1.0"
 dependencies = [
  "cushy",
+ "slotmap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabbed-document-ui"
+version = "0.1.0"
+dependencies = [
+ "cushy",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["cushy-macros", "guide/guide-examples"]
+members = ["cushy-macros", "guide/guide-examples", "examples/tabbed-document-ui"]
 
 [package]
 name = "cushy"

--- a/examples/dynamic_tabs.rs
+++ b/examples/dynamic_tabs.rs
@@ -1,0 +1,84 @@
+use cushy::value::{Destination, Dynamic, Source};
+use cushy::widget::{MakeWidget, WidgetInstance, WidgetList};
+use cushy::widgets::Space;
+use cushy::Run;
+
+#[derive(Default, PartialEq)]
+struct TabBar {
+    tabs: Vec<Tab>,
+}
+
+impl TabBar {
+    pub fn add_tab(&mut self, tab: Tab) {
+        self.tabs.push(tab);
+    }
+}
+
+#[derive(PartialEq)]
+enum Tab {
+    Home,
+    Text { title: String, contents: String },
+}
+
+impl Tab {
+    pub fn label(&self) -> &str {
+        match self {
+            Tab::Home => "Home",
+            Tab::Text { title, .. } => title,
+        }
+    }
+
+    pub fn make_content(&self) -> WidgetInstance {
+        match self {
+            Tab::Home => "This is the home tab".make_widget(),
+            Tab::Text { contents, .. } => contents.make_widget(),
+        }
+    }
+}
+
+fn main() -> cushy::Result {
+    let tabs = Dynamic::new(TabBar::default());
+    let home = "Home".into_button().on_click({
+        let tabs = tabs.clone();
+        move |_| tabs.lock().add_tab(Tab::Home)
+    });
+    let second_button = "New Tab".into_button().on_click({
+        let tabs = tabs.clone();
+        let mut counter = 0;
+        move |_| {
+            counter += 1;
+            tabs.lock().add_tab(Tab::Text {
+                title: format!("Tab {counter}"),
+                contents: format!("This is tab {counter}"),
+            })
+        }
+    });
+
+    // Create an empty area for the active tab to be displayed.
+    let content_area = Dynamic::new(Space::clear().make_widget());
+
+    home.and(second_button)
+        .into_columns()
+        .and(make_tab_bar(&tabs, &content_area))
+        .and(content_area.expand())
+        .into_rows()
+        .expand()
+        .run()
+}
+
+fn make_tab_bar(tabs: &Dynamic<TabBar>, content_area: &Dynamic<WidgetInstance>) -> impl MakeWidget {
+    let content_area = content_area.clone();
+    tabs.map_each(move |bar| {
+        bar.tabs
+            .iter()
+            .map(|tab| {
+                let content = tab.make_content();
+                tab.label().into_button().on_click({
+                    let content_area = content_area.clone();
+                    move |_| content_area.set(content.clone())
+                })
+            })
+            .collect::<WidgetList>()
+    })
+        .into_columns()
+}

--- a/examples/tabbed-document-ui/Cargo.toml
+++ b/examples/tabbed-document-ui/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tabbed-document-ui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cushy = { path = "../.."}

--- a/examples/tabbed-document-ui/Cargo.toml
+++ b/examples/tabbed-document-ui/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 cushy = { path = "../.."}
+
+slotmap = { version = "1.0.7" }

--- a/examples/tabbed-document-ui/src/main.rs
+++ b/examples/tabbed-document-ui/src/main.rs
@@ -92,9 +92,18 @@ fn make_toolbar(tab_bar: Dynamic<TabBar<TabKind>>) -> Stack {
         .into_button();
 
     let close_all_button = "Close all"
-        .into_button();
+        .into_button()
+        .on_click({
+            let tab_bar = tab_bar.clone();
+            move |_| {
+                println!("close all clicked");
 
-    let toolbar_widgets: [WidgetInstance; 5] = [
+                tab_bar.lock().close_all();
+            }
+        });
+
+
+                      let toolbar_widgets: [WidgetInstance; 5] = [
         home_button.make_widget(),
         new_button.make_widget(),
         open_button.make_widget(),

--- a/examples/tabbed-document-ui/src/main.rs
+++ b/examples/tabbed-document-ui/src/main.rs
@@ -13,7 +13,7 @@ mod widgets;
 
 mod tabs {
     use cushy::widget::{MakeWidget, WidgetInstance};
-    use crate::widgets::tab_bar::TabThing;
+    use crate::widgets::tab_bar::Tab;
 
     #[derive(Hash, PartialEq, Eq, Clone)]
     pub enum TabKind {
@@ -21,7 +21,7 @@ mod tabs {
         Document,
     }
 
-    impl TabThing for TabKind {
+    impl Tab for TabKind {
         fn label(&self) -> String {
             match self {
                 TabKind::Home => "Home".to_string(),
@@ -44,7 +44,7 @@ struct AppState {
 
 fn main() -> cushy::Result {
 
-    let mut tab_bar = Dynamic::new(make_tab_bar());
+    let tab_bar = Dynamic::new(make_tab_bar());
     let toolbar = make_toolbar(tab_bar.clone());
 
     let app_state = AppState {
@@ -53,7 +53,7 @@ fn main() -> cushy::Result {
 
     let ui_elements = [
         toolbar.make_widget(),
-        app_state.tab_bar.lock().clone().make_widget(),
+        app_state.tab_bar.lock().make_widget(),
     ];
 
     let ui = ui_elements

--- a/examples/tabbed-document-ui/src/main.rs
+++ b/examples/tabbed-document-ui/src/main.rs
@@ -1,0 +1,110 @@
+use cushy::figures::units::Px;
+use cushy::Run;
+use cushy::styles::Color;
+use cushy::styles::components::DefaultBackgroundColor;
+use cushy::value::{Dynamic, Source};
+use cushy::widget::{IntoWidgetList, MakeWidget, Widget, WidgetInstance, WidgetList};
+use cushy::widgets::{Expand, Stack};
+use cushy::widgets::grid::Orientation;
+use crate::tabs::TabKind;
+use crate::widgets::tab_bar::TabBar;
+
+mod widgets;
+
+mod tabs {
+    use cushy::widget::{MakeWidget, WidgetInstance};
+    use crate::widgets::tab_bar::TabThing;
+
+    #[derive(Hash, PartialEq, Eq, Clone)]
+    pub enum TabKind {
+        Home,
+        Document,
+    }
+
+    impl TabThing for TabKind {
+        fn label(&self) -> String {
+            match self {
+                TabKind::Home => "Home".to_string(),
+                TabKind::Document => "Document".to_string(),
+            }
+        }
+
+        fn make_content(&self) -> WidgetInstance {
+            match self {
+                TabKind::Home => "Home tab content".make_widget(),
+                TabKind::Document => "Document tab content".make_widget(),
+            }
+        }
+    }
+}
+
+struct AppState {
+    tab_bar: Dynamic<TabBar<TabKind>>
+}
+
+fn main() -> cushy::Result {
+
+    let mut tab_bar = Dynamic::new(make_tab_bar());
+    let toolbar = make_toolbar(tab_bar.clone());
+
+    let app_state = AppState {
+        tab_bar: tab_bar.clone()
+    };
+
+    let ui_elements = [
+        toolbar.make_widget(),
+        app_state.tab_bar.lock().clone().make_widget(),
+    ];
+
+    let ui = ui_elements
+        .into_rows()
+        .width(Px::new(1024))
+        .height(Px::new(768));
+
+    ui.run()
+}
+
+fn make_tab_bar() -> TabBar<TabKind> {
+    TabBar::new()
+}
+
+fn make_toolbar(tab_bar: Dynamic<TabBar<TabKind>>) -> Stack {
+    let home_button = "Home"
+        .into_button()
+        .on_click({
+            let tab_bar = tab_bar.clone();
+            move |_|{
+                println!("home clicked");
+
+                tab_bar.lock().add_tab(TabKind::Home);
+            }
+        });
+
+    let new_button = "New"
+        .into_button()
+        .on_click({
+            let tab_bar = tab_bar.clone();
+            move |_|{
+                println!("New clicked");
+
+                tab_bar.lock().add_tab(TabKind::Document);
+            }
+        });
+
+    let open_button = "Open"
+        .into_button();
+
+    let close_all_button = "Close all"
+        .into_button();
+
+    let toolbar_widgets: [WidgetInstance; 5] = [
+        home_button.make_widget(),
+        new_button.make_widget(),
+        open_button.make_widget(),
+        close_all_button.make_widget(),
+        Expand::empty().make_widget(),
+    ];
+
+    let toolbar = toolbar_widgets.into_columns();
+    toolbar
+}

--- a/examples/tabbed-document-ui/src/main.rs
+++ b/examples/tabbed-document-ui/src/main.rs
@@ -103,7 +103,7 @@ fn make_toolbar(tab_bar: Dynamic<TabBar<TabKind>>) -> Stack {
         });
 
 
-                      let toolbar_widgets: [WidgetInstance; 5] = [
+    let toolbar_widgets: [WidgetInstance; 5] = [
         home_button.make_widget(),
         new_button.make_widget(),
         open_button.make_widget(),

--- a/examples/tabbed-document-ui/src/main.rs
+++ b/examples/tabbed-document-ui/src/main.rs
@@ -1,11 +1,8 @@
 use cushy::figures::units::Px;
 use cushy::Run;
-use cushy::styles::Color;
-use cushy::styles::components::DefaultBackgroundColor;
-use cushy::value::{Dynamic, Source};
-use cushy::widget::{IntoWidgetList, MakeWidget, Widget, WidgetInstance, WidgetList};
+use cushy::value::{Dynamic};
+use cushy::widget::{IntoWidgetList, MakeWidget, WidgetInstance};
 use cushy::widgets::{Expand, Stack};
-use cushy::widgets::grid::Orientation;
 use crate::tabs::TabKind;
 use crate::widgets::tab_bar::TabBar;
 

--- a/examples/tabbed-document-ui/src/widgets/mod.rs
+++ b/examples/tabbed-document-ui/src/widgets/mod.rs
@@ -1,0 +1,1 @@
+pub mod tab_bar;

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -51,6 +51,8 @@ impl<TK: Tab + Hash + Eq + Sync + Send + 'static> TabBar<TK> {
         self.tab_items
             .lock()
             .push(select);
+
+        self.selected.set(Some(tab_key));
     }
 
     pub fn make_widget(&self) -> WidgetInstance {

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+use cushy::figures::units::Px;
+use cushy::styles::Color;
+use cushy::styles::components::DefaultBackgroundColor;
+use cushy::value::{Destination, Dynamic, Source};
+use cushy::widget::{IntoWidgetList, MakeWidget, WidgetInstance, WidgetList};
+use cushy::widgets::grid::Orientation;
+use cushy::widgets::{Expand, Space, Stack};
+use crate::tabs::TabKind;
+
+pub trait TabThing {
+    fn label(&self) -> String;
+    fn make_content(&self) -> WidgetInstance;
+}
+
+#[derive(Clone)]
+pub struct TabBar<TK: Clone> {
+    tabs: Vec<TK>,
+    tab_items: Dynamic<WidgetList>,
+    content_area: Dynamic<WidgetInstance>,
+}
+
+impl<TK: TabThing + Hash + Eq + Clone > TabBar<TK> {
+    pub fn new() -> Self {
+        let tabs: Vec<TK> = vec![];
+        let content_area = Dynamic::new(Space::clear().make_widget());
+
+        Self {
+            tabs,
+            content_area,
+            tab_items: Dynamic::new(WidgetList::new()),
+        }
+    }
+
+    pub fn add_tab(&mut self, tab: TK) {
+        let content = tab.make_content();
+
+        let tab_button = tab.label()
+            .into_button()
+            .on_click({
+                let content_area = self.content_area.clone();
+                move |_| content_area.set(content.clone())
+            })
+            .make_widget();
+        self.tab_items.lock().push(tab_button)
+    }
+
+}
+
+impl<TK: Clone> MakeWidget for TabBar<TK> {
+    fn make_widget(self) -> WidgetInstance {
+
+        let tab_bar: Stack = [
+            Stack::new(Orientation::Column, self.tab_items)
+                .make_widget(),
+            Expand::empty()
+                .with(&DefaultBackgroundColor, Color::RED)
+                .height(Px::new(32))
+                .make_widget(),
+        ].into_columns();
+
+        tab_bar
+            .and(self.content_area.expand())
+            .into_rows()
+            .make_widget()
+    }
+}

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -27,8 +27,8 @@ new_key_type! {
     pub struct TabKey;
 }
 
-// FIXME avoid the ` + Sync + Send + 'static` requirement if possible, required due to use of `Source::for_each`
-impl<TK: Tab + Hash + Eq + Sync + Send + 'static> TabBar<TK> {
+// FIXME avoid the ` + Send + 'static` requirement if possible, required due to use of `Source::for_each`
+impl<TK: Tab + Hash + Eq + Send + 'static> TabBar<TK> {
     pub fn new() -> Self {
         let tabs: SlotMap<TabKey, TK> = Default::default();
         let content_area = Dynamic::new(Space::clear().make_widget());

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -3,8 +3,8 @@ use std::hash::Hash;
 use slotmap::{new_key_type, SlotMap};
 use cushy::figures::units::Px;
 use cushy::styles::Color;
-use cushy::styles::components::DefaultBackgroundColor;
-use cushy::value::{Destination, Dynamic, IntoValue, Source};
+use cushy::styles::components::WidgetBackground;
+use cushy::value::{Destination, Dynamic, Source};
 use cushy::widget::{IntoWidgetList, MakeWidget, WidgetInstance, WidgetList};
 use cushy::widgets::grid::Orientation;
 use cushy::widgets::{Expand, Space, Stack};
@@ -92,14 +92,20 @@ struct TabBarWidget {
 impl MakeWidget for TabBarWidget {
     fn make_widget(self) -> WidgetInstance {
 
-        let tab_bar: Stack = [
+        let tab_bar = [
             Stack::new(Orientation::Column, self.tab_items)
                 .make_widget(),
             Expand::empty()
-                .with(&DefaultBackgroundColor, Color::RED)
-                .height(Px::new(32))
+                // FIXME this causes the tab bar to take the entire height of the area under the toolbar unless a height is specified
+                //       but we don't want to specify a height in pixels, we want the height to be be automatic
+                //       like it is when the background color is not specified.
+                .with(&WidgetBackground, Color::DARKGRAY)
+                // FIXME remove this, see above.
+                .height(Px::new(38))
                 .make_widget(),
-        ].into_columns();
+        ]
+            .into_columns()
+            .with(&WidgetBackground, Color::GRAY);
 
         tab_bar
             .and(self.content_area.expand())

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -2,12 +2,14 @@ use std::default::Default;
 use std::hash::Hash;
 use slotmap::{new_key_type, SlotMap};
 use cushy::figures::units::Px;
-use cushy::styles::Color;
-use cushy::styles::components::WidgetBackground;
+use cushy::styles::{Color, CornerRadii, Dimension};
+use cushy::styles::components::{CornerRadius, TextColor, WidgetBackground};
 use cushy::value::{Destination, Dynamic, Source};
 use cushy::widget::{IntoWidgetList, MakeWidget, WidgetInstance, WidgetList};
 use cushy::widgets::grid::Orientation;
 use cushy::widgets::{Expand, Space, Stack};
+use cushy::widgets::button::{ButtonActiveBackground, ButtonActiveForeground, ButtonBackground, ButtonForeground, ButtonHoverForeground};
+use cushy::widgets::select::SelectedColor;
 
 pub trait Tab {
     fn label(&self) -> String;
@@ -46,7 +48,12 @@ impl<TK: Tab + Hash + Eq + Send + 'static> TabBar<TK> {
 
         let tab_key = self.tabs.lock().insert(tab);
         println!("tab_key: {:?}", tab_key);
-        let select = self.selected.new_select(Some(tab_key), tab_label);
+        let select = self.selected
+            .new_select(Some(tab_key), tab_label)
+            .with(&ButtonForeground, Color::LIGHTGRAY)
+            .with(&ButtonHoverForeground, Color::WHITE)
+            .with(&ButtonActiveBackground, Color::GRAY)
+            .with(&SelectedColor, Color::GRAY);
 
         self.tab_items
             .lock()
@@ -89,6 +96,8 @@ impl<TK: Tab + Hash + Eq + Send + 'static> TabBar<TK> {
     }
 }
 
+static VERY_DARK_GREY: Color = Color::new(0x32, 0x32, 0x32, 255);
+
 // Intermediate widget, with only the things it needs, so that it's possible to call `make_widget` which consumes self.
 struct TabBarWidget {
     tab_items: Dynamic<WidgetList>,
@@ -105,17 +114,19 @@ impl MakeWidget for TabBarWidget {
                 // FIXME this causes the tab bar to take the entire height of the area under the toolbar unless a height is specified
                 //       but we don't want to specify a height in pixels, we want the height to be be automatic
                 //       like it is when the background color is not specified.
-                .with(&WidgetBackground, Color::DARKGRAY)
+                .with(&WidgetBackground, VERY_DARK_GREY)
                 // FIXME remove this, see above.
                 .height(Px::new(38))
                 .make_widget(),
         ]
             .into_columns()
-            .with(&WidgetBackground, Color::GRAY);
+            .with(&WidgetBackground, VERY_DARK_GREY)
+            .with(&TextColor, Color::GRAY);
 
         tab_bar
             .and(self.content_area.expand())
             .into_rows()
+            .with(&CornerRadius, CornerRadii::from(Dimension::Px(Px::new(0))))
             .make_widget()
     }
 }

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -57,8 +57,7 @@ impl<TK: Tab + Hash + Eq + Send + 'static> TabBar<TK> {
 
     pub fn close_all(&mut self) {
         self.selected.set(None);
-        // FIXME couldn't find `.clear()` or `.empty()` or similar on `WidgetList`, using `.truncate() instead`
-        self.tab_items.lock().truncate(0);
+        self.tab_items.lock().clear();
         self.tabs.lock().clear();
     }
 

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -56,7 +56,7 @@ impl<TK: Tab + Hash + Eq + Sync + Send + 'static> TabBar<TK> {
 
     pub fn make_widget(&self) -> WidgetInstance {
 
-        self.selected
+        let callback = self.selected
             .for_each({
                 let tabs = self.tabs.clone();
                 let content_area = self.content_area.clone();
@@ -69,6 +69,7 @@ impl<TK: Tab + Hash + Eq + Sync + Send + 'static> TabBar<TK> {
                     }
                 }
             });
+        callback.persist();
 
         let widget = TabBarWidget {
             tab_items: self.tab_items.clone(),

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -107,18 +107,8 @@ struct TabBarWidget {
 impl MakeWidget for TabBarWidget {
     fn make_widget(self) -> WidgetInstance {
 
-        let tab_bar = [
-            Stack::new(Orientation::Column, self.tab_items)
-                .make_widget(),
-            Expand::empty()
-                // FIXME this causes the tab bar to take the entire height of the area under the toolbar unless a height is specified
-                //       but we don't want to specify a height in pixels, we want the height to be be automatic
-                //       like it is when the background color is not specified.
-                .with(&WidgetBackground, VERY_DARK_GREY)
-                // FIXME remove this, see above.
-                .height(Px::new(38))
-                .make_widget(),
-        ]
+        let tab_bar = self.tab_items.into_columns()
+            .and(Expand::empty())
             .into_columns()
             .with(&WidgetBackground, VERY_DARK_GREY)
             .with(&TextColor, Color::GRAY);

--- a/examples/tabbed-document-ui/src/widgets/tab_bar.rs
+++ b/examples/tabbed-document-ui/src/widgets/tab_bar.rs
@@ -55,6 +55,13 @@ impl<TK: Tab + Hash + Eq + Send + 'static> TabBar<TK> {
         self.selected.set(Some(tab_key));
     }
 
+    pub fn close_all(&mut self) {
+        self.selected.set(None);
+        // FIXME couldn't find `.clear()` or `.empty()` or similar on `WidgetList`, using `.truncate() instead`
+        self.tab_items.lock().truncate(0);
+        self.tabs.lock().clear();
+    }
+
     pub fn make_widget(&self) -> WidgetInstance {
 
         let callback = self.selected

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -2160,6 +2160,11 @@ impl WidgetList {
         self.ordered.truncate(length);
     }
 
+    /// Clear the list
+    pub fn clear(&mut self) {
+        self.ordered.clear();
+    }
+
     /// Returns `self` as a vertical [`Stack`] of rows.
     #[must_use]
     pub fn into_rows(self) -> Stack {


### PR DESCRIPTION
The reason for the make_widgets is due to Rust not supporting multiple
types in an array. A tuple is perfect for this, but due to restrictions
in the Rust type system, I can't implement MakeWidgetList for tuples
*and* IntoIterator, because I get an error saying that IntoIterator
could be added someday to tuples.

Because I know this is a pain point, WidgetList is the type I created to
try to help solve these usability issues. The `widget.and(other_widget)`
syntax is the recommended way to avoid having to call make_widget when
creating lists of widgets.